### PR TITLE
ipython3 notebook added

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can view your API key on the [Planet OS account settings page](http://data.p
 
 Launch Jupyter with the following command:
 
-`jupyter notebook`
+`jupyter notebook` or `ipython3 notebook`
 
 By default, the command above will open a new browser tab at http://127.0.0.1:8888 which lists the available notebooks in a directory view.
 


### PR DESCRIPTION
sometimes jupyter notebook won't run (e.g. https://github.com/jupyter/notebook/issues/448). If it is the case ipython3 notebook will come handy